### PR TITLE
Ensure that Solr <5 runs as the proper user on Debian-based systems

### DIFF
--- a/templates/solr-init-Debian-pre5.j2
+++ b/templates/solr-init-Debian-pre5.j2
@@ -25,7 +25,7 @@ LOG_FILE="{{ solr_log_file_path }}"
 start () {
     echo -n "Starting {{ solr_service_name }}... "
 
-    daemon -U --chdir="$SOLR_DIR" --command "$START_COMMAND" --respawn --output=$LOG_FILE --name={{ solr_service_name }}
+    daemon -U --chdir="$SOLR_DIR" --command "$START_COMMAND" --respawn --output=$LOG_FILE --name={{ solr_service_name }} --user={{ solr_user }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -40,7 +40,7 @@ start () {
 stop () {
     echo -n "Stopping {{ solr_service_name }}... "
 
-    daemon --stop --name={{ solr_service_name }}
+    daemon --stop --name={{ solr_service_name }} --user={{ solr_user }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -54,7 +54,7 @@ stop () {
 
 restart () {
     echo -n "Restarting solr... "
-    daemon --restart --name={{ solr_service_name }}
+    daemon --restart --name={{ solr_service_name }} --user={{ solr_user }}
 
     RETVAL=$?
     if [ $RETVAL = 0 ]
@@ -68,7 +68,7 @@ restart () {
 
 check_status () {
     # Report on the status of the daemon
-    daemon --running --name={{ solr_service_name }} --verbose
+    daemon --running --name={{ solr_service_name }} --user={{ solr_user }} --verbose
     return $?
 }
 


### PR DESCRIPTION
The init script for Solr < 5 on Debian-based systems runs Solr as root instead of `{{ solr_user }}`